### PR TITLE
update launcher URL

### DIFF
--- a/com.albiononline.AlbionOnline.json
+++ b/com.albiononline.AlbionOnline.json
@@ -12,7 +12,7 @@
         "--share=network",
         "--device=dri",
         "--persist=.albiononline",
-        "--extra-data=albion-online-setup:890e5347844260e0108f12beb7bf137d33fbcc36a896874286c2c21521154289:70000140::https://live.albiononline.com/clients/20170707094539/albion-online-setup"
+        "--extra-data=albion-online-setup:890e5347844260e0108f12beb7bf137d33fbcc36a896874286c2c21521154289:69463596::https://live.albiononline.com/clients/20170713161744/albion-online-setup"
     ],
     "modules": [
         "shared-modules/udev/udev-175.json",


### PR DESCRIPTION
Flatpak can no longer download launcher via extra data because it's telling that file size is different. 
I updated URL, sha256sum and size. I guess it's right although I don't know how to test it.