### PR TITLE
Switch to Freedesktop SDK

### DIFF
--- a/com.albiononline.AlbionOnline.json
+++ b/com.albiononline.AlbionOnline.json
@@ -1,8 +1,8 @@
 {
     "app-id": "com.albiononline.AlbionOnline",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "3.32",
-    "sdk": "org.gnome.Sdk",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "18.08",
+    "sdk": "org.freedesktop.Sdk",
     "command": "albion-online",
     "tags": [
         "proprietary"


### PR DESCRIPTION
There is a plugin (ScreenSelector.so) that linked to a library present
in org.gnome.Platform. This library is not available in newer version
so there is no point to continue using org.gnome.Platform.