### PR TITLE
Fixing launcher update loop in get_download_uri.py

### DIFF
--- a/get_download_uri.py
+++ b/get_download_uri.py
@@ -12,4 +12,11 @@ doc = ET.parse(manifest)
 fullinstall = doc.find('installer/linux/fullinstall')
 name = fullinstall.attrib['file']
 version = fullinstall.attrib['version']
+
+# fixing version syntax mismatch, 1.0.34.341 != 1.0.034.341
+# checking it against file name version for now, until they fix it
+name_version = name.split('-')[-1]
+if name_version != version:
+    version = '.'.join(map(lambda v: str(int(v)) if v.isalnum() else v, version.split('.')))
+
 print("{};{}".format(urljoin(base_uri, name), version))


### PR DESCRIPTION
_albion-online.sh_ file keeps on updating launcher every time the game is launched because of a trailing 0 before 34 in the version.

version in _~/.albiononline/launcher/version.txt_
`launcher-linux-full-1.0.34.341`

installed_version fetched from _get_download_uri.py_
`https://live.albiononline.com/autoupdate/launcher-linux-setup-1.0.34.341;1.0.034.341`

Because of this, this condition fails every time in _albion-online.sh_ and it keeps on downloading it
`if [ "${version}" != "${installed_version}" ]; then`

updated _get_download_uri.py_, removing that trailing 0 before 34
`https://live.albiononline.com/autoupdate/launcher-linux-setup-1.0.34.341;1.0.34.341`

https://live.albiononline.com/autoupdate/manifest.xml shows that the trailing 0 in the version format is used everywhere, it seems like they haven't updated the format in version.txt (and launcher-linux-setup-x.x.xx.xxx). Since they might update it in the future, it could be safe to check it against the filename version.
```
name_version = name.split('-')[-1]
if name_version != version:
```