### PR TITLE
Freedesktop SDK out of date

### DIFF
--- a/com.albiononline.AlbionOnline.json
+++ b/com.albiononline.AlbionOnline.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.albiononline.AlbionOnline",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "albion-online",
     "tags": [

--- a/com.albiononline.AlbionOnline.json
+++ b/com.albiononline.AlbionOnline.json
@@ -21,8 +21,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://www.sndio.org/sndio-1.2.0.tar.gz",
-                    "sha256": "b9808e189481904a4404b0c1715ad0c4b301e72abca8e49653bb526ff4e16cdc"
+                    "url": "http://www.sndio.org/sndio-1.8.1.tar.gz",
+                    "sha256": "f81d37189e072cb4804ac98a059d74f963f69e9945eaff3d0d6a2f98d71a6321"
                 }
             ]
         },

--- a/com.albiononline.AlbionOnline.json
+++ b/com.albiononline.AlbionOnline.json
@@ -80,9 +80,9 @@
                 {
                     "type": "extra-data",
                     "filename": "albion-online-setup",
-                    "url": "https://live.albiononline.com/autoupdate/launcher-linux-setup-1.0.34.253",
-                    "sha256": "b2b465c7696df9c368db828d139115d6179a327f2968f1f64d96daa44d82063d",
-                    "size": 87116891
+                    "url": "https://live.albiononline.com/autoupdate/launcher-linux-setup-1.0.34.342",
+                    "sha256": "e22b9f1f2eee2655f8516670faaa04d7bbac732d1ae7101505d91c143995491a",
+                    "size": 87153536
                 }
             ]
         }


### PR DESCRIPTION
The current Freedesktop runtime is out of date, as are a couple of dependencies, this PR addresses those.

```
[willwh@claymore ~]$ flatpak update
Looking for updates…
Info: org.freedesktop.Platform//19.08 is end-of-life, with reason:
   The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
Applications using this runtime:
   com.albiononline.AlbionOnline
Info: org.freedesktop.Platform.GL.default//19.08 is end-of-life, with reason:
   The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
Nothing to do.
```