### PR TITLE
Make it run again

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -7,6 +7,3 @@ unzip albion-online-setup.zip 'data/*'
 mv data/* .
 rm -rf data
 rm albion-online-setup
-
-mkdir -p export/share/icons/hicolor/128x128/apps
-cp AlbionOnline.xpm export/share/icons/hicolor/128x128/apps/com.albiononline.AlbionOnline.xpm

--- a/com.albiononline.AlbionOnline.json
+++ b/com.albiononline.AlbionOnline.json
@@ -80,9 +80,9 @@
                 {
                     "type": "extra-data",
                     "filename": "albion-online-setup",
-                    "url": "https://live.albiononline.com/autoupdate/launcher-linux-setup-1.0.34.253",
-                    "sha256": "b2b465c7696df9c368db828d139115d6179a327f2968f1f64d96daa44d82063d",
-                    "size": 87116891
+                    "url": "https://live.albiononline.com/autoupdate/launcher-linux-setup-1.0.34.392",
+                    "sha256": "50620c0db12d8b14491526984d5ebf90e1cd7cd4bdafe9a5244b9d04b567a3ab",
+                    "size": 104005538
                 }
             ]
         }

--- a/com.albiononline.AlbionOnline.json
+++ b/com.albiononline.AlbionOnline.json
@@ -17,6 +17,21 @@
     ],
     "modules": [
         {
+            "name": "krb5",
+            "subdir": "src",
+            "config-opts": [
+                "--disable-static",
+                "--disable-rpath"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://kerberos.org/dist/krb5/1.19/krb5-1.19.2.tar.gz",
+                    "sha256": "10453fee4e3a8f8ce6129059e5c050b8a65dab1c257df68b99b3112eaa0cdf6a"
+                }
+            ]
+        },
+        {
             "name": "sndio",
             "sources": [
                 {

--- a/com.albiononline.AlbionOnline.json
+++ b/com.albiononline.AlbionOnline.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.albiononline.AlbionOnline",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "albion-online",
     "tags": [


### PR DESCRIPTION
 - Update Freedeskop SDK to 21.08
 - Update launcher to 1.0.34.392
 - Add missing krb5 dependency
 - Remove installation of xpm icon